### PR TITLE
Visible tag after dismount

### DIFF
--- a/src/main/java/com/owen1212055/customname/listener/PlayerSneakListener.java
+++ b/src/main/java/com/owen1212055/customname/listener/PlayerSneakListener.java
@@ -25,7 +25,7 @@ public class PlayerSneakListener implements Listener {
     public void toggleSneak(PlayerToggleSneakEvent event) {
         CustomName playerName = this.nameStorage.getCustomPlayerName(event.getPlayer().getUniqueId());
         // Does the entity have a custom name?
-        if (playerName != null) {
+        if (playerName != null && !event.getPlayer().isInsideVehicle()) {
             playerName.setTargetEntitySneaking(event.isSneaking());
         }
     }


### PR DESCRIPTION
If you press SHIFT to exit out a vehicle your tag is in sneaking state until your next sneak. This solves the problem.