### PR TITLE
Player ride desync

### DIFF
--- a/src/main/java/com/owen1212055/customname/CustomName.java
+++ b/src/main/java/com/owen1212055/customname/CustomName.java
@@ -51,13 +51,11 @@ public class CustomName {
         this.passengerOffset = ridingOffset;
 
         this.task = new BukkitRunnable() {
-
-            private final Packet<ClientGamePacketListener> packet = interaction.getRiderPacket();
-
             @Override
             public void run() {
+                Packet<ClientGamePacketListener> riderPacket = CustomName.this.interaction.getRiderPacket();
                 for (Player player : entity.getTrackedPlayers()) {
-                    ((CraftPlayer) player).getHandle().connection.send(packet);
+                    ((CraftPlayer) player).getHandle().connection.send(riderPacket);
                 }
             }
         }.runTaskTimer(CustomNamePlugin.getProvidingPlugin(CustomNamePlugin.class), 20, 20);
@@ -141,5 +139,9 @@ public class CustomName {
 
     public void close() {
         this.task.cancel();
+    }
+
+    public boolean isHidden() {
+        return this.hidden;
     }
 }

--- a/src/main/java/com/owen1212055/customname/util/SkeletonInteraction.java
+++ b/src/main/java/com/owen1212055/customname/util/SkeletonInteraction.java
@@ -12,6 +12,7 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.Pose;
 import net.minecraft.world.phys.Vec3;
 import org.bukkit.Location;
+import org.bukkit.entity.Entity;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -48,9 +49,25 @@ public class SkeletonInteraction {
     public Packet<ClientGamePacketListener> getRiderPacket() {
         FriendlyByteBuf buf = new FriendlyByteBuf(Unpooled.buffer());
         buf.writeVarInt(this.customName.getTargetEntity().getEntityId());
-        buf.writeVarIntArray(new int[]{this.customName.getNametagId()});
+
+        int[] passengerIds = this.passengerIds();
+        buf.writeVarIntArray(passengerIds);
 
         return new ClientboundSetPassengersPacket(buf);
+    }
+
+    private int[] passengerIds() {
+        List<Entity> passengers = this.customName.getTargetEntity().getPassengers(); //respect passengers
+        int[] passengerIds = new int[passengers.size()];
+        if (!this.customName.isHidden()) {
+            int length = passengerIds.length;
+            passengerIds = new int[length + 1];
+            passengerIds[length] = this.customName.getNametagId(); //always add the entity if it is visible
+        }
+        for (int i = 0; i < passengers.size(); i++) {
+            passengerIds[i] = passengers.get(i).getEntityId();
+        }
+        return passengerIds;
     }
 
     public Packet<?> initialSpawnPacket() {


### PR DESCRIPTION
`player.addPassenger(other)` this causes some issues such as desync of the passenger or, from a view of a third player, disabled movement of entities while riding a player.