### PR TITLE
3rd party client crash

### DIFF
--- a/src/main/java/com/owen1212055/customname/util/SkeletonInteraction.java
+++ b/src/main/java/com/owen1212055/customname/util/SkeletonInteraction.java
@@ -64,7 +64,7 @@ public class SkeletonInteraction {
         ));
         Packet<ClientGamePacketListener> syncData = syncDataPacket();
         ClientboundSetEntityDataPacket afterCreateData = new ClientboundSetEntityDataPacket(this.customName.getNametagId(), List.of(
-                ofData(DataAccessors.DATA_HEIGHT_ID, 99999999f)
+                ofData(DataAccessors.DATA_HEIGHT_ID, 511f)
         ));
 
         return new ClientboundBundlePacket(List.of(


### PR DESCRIPTION
Some 3rd party clients may crash on higher values. `511` which is `1 1111 1111` in binary should be enough.